### PR TITLE
feat: melt from pipe and to STDOUT

### DIFF
--- a/cmd/melt/main.go
+++ b/cmd/melt/main.go
@@ -120,11 +120,7 @@ be used to rebuild your public and private keys.`,
 				return err
 			}
 
-			bts, err := maybeFile(mnemonic)
-			if err != nil {
-				return err
-			}
-			if err := restore(string(bts), args[0], askNewPassphrase); err != nil {
+			if err := restore(maybeFile(mnemonic), args[0], askNewPassphrase); err != nil {
 				return err
 			}
 
@@ -169,18 +165,18 @@ func main() {
 	}
 }
 
-func maybeFile(s string) ([]byte, error) {
+func maybeFile(s string) string {
 	if s == "-" {
 		bts, err := io.ReadAll(os.Stdin)
 		if err == nil {
-			return bts, nil
+			return string(bts)
 		}
 	}
 	bts, err := os.ReadFile(s)
 	if err != nil {
-		return []byte(s), nil
+		return s
 	}
-	return bts, nil
+	return string(bts)
 }
 
 func parsePrivateKey(bts, pass []byte) (interface{}, error) {
@@ -193,7 +189,7 @@ func parsePrivateKey(bts, pass []byte) (interface{}, error) {
 }
 
 func backup(path string, pass []byte) (string, error) {
-	bts, err := maybeFile(path)
+	bts, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("could not read key: %w", err)
 	}

--- a/cmd/melt/main.go
+++ b/cmd/melt/main.go
@@ -281,8 +281,10 @@ func restore(mnemonic string, passFn func() ([]byte, error), outFn func(pem, pub
 
 func restoreToWriter(w io.Writer) func(pem, _ []byte) error {
 	return func(pem, _ []byte) error {
-		_, err := fmt.Fprint(w, string(pem))
-		return err
+		if _, err := fmt.Fprint(w, string(pem)); err != nil {
+			return fmt.Errorf("could not write private key: %w", err)
+		}
+		return nil
 	}
 }
 

--- a/cmd/melt/main.go
+++ b/cmd/melt/main.go
@@ -120,7 +120,11 @@ be used to rebuild your public and private keys.`,
 				return err
 			}
 
-			if err := restore(maybeFile(mnemonic), args[0], askNewPassphrase); err != nil {
+			bts, err := maybeFile(mnemonic)
+			if err != nil {
+				return err
+			}
+			if err := restore(string(bts), args[0], askNewPassphrase); err != nil {
 				return err
 			}
 
@@ -165,18 +169,18 @@ func main() {
 	}
 }
 
-func maybeFile(s string) string {
+func maybeFile(s string) ([]byte, error) {
 	if s == "-" {
 		bts, err := io.ReadAll(os.Stdin)
 		if err == nil {
-			return string(bts)
+			return bts, nil
 		}
 	}
 	bts, err := os.ReadFile(s)
 	if err != nil {
-		return s
+		return []byte(s), nil
 	}
-	return string(bts)
+	return bts, nil
 }
 
 func parsePrivateKey(bts, pass []byte) (interface{}, error) {
@@ -189,7 +193,7 @@ func parsePrivateKey(bts, pass []byte) (interface{}, error) {
 }
 
 func backup(path string, pass []byte) (string, error) {
-	bts, err := os.ReadFile(path)
+	bts, err := maybeFile(path)
 	if err != nil {
 		return "", fmt.Errorf("could not read key: %w", err)
 	}

--- a/cmd/melt/main.go
+++ b/cmd/melt/main.go
@@ -189,7 +189,13 @@ func parsePrivateKey(bts, pass []byte) (interface{}, error) {
 }
 
 func backup(path string, pass []byte) (string, error) {
-	bts, err := os.ReadFile(path)
+	var bts []byte
+	var err error
+	if path == "-" {
+		bts, err = io.ReadAll(os.Stdin)
+	} else {
+		bts, err = os.ReadFile(path)
+	}
 	if err != nil {
 		return "", fmt.Errorf("could not read key: %w", err)
 	}

--- a/cmd/melt/main.go
+++ b/cmd/melt/main.go
@@ -197,7 +197,11 @@ func openFileOrStdin(path string) (*os.File, error) {
 		return os.Stdin, nil
 	}
 
-	return os.Open(path)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not open %s: %w", path, err)
+	}
+	return f, nil
 }
 
 func parsePrivateKey(bts, pass []byte) (interface{}, error) {

--- a/cmd/melt/main_test.go
+++ b/cmd/melt/main_test.go
@@ -181,17 +181,24 @@ func TestMaybeFile(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "f")
 		content := "test content"
 		is.NoErr(os.WriteFile(path, []byte(content), 0o644)) // nolint: gomnd
-		is.Equal(content, maybeFile(path))
+
+		bts, err := maybeFile(path)
+		is.NoErr(err)
+		is.Equal(content, string(bts))
 	})
 
 	t.Run("not a file", func(t *testing.T) {
 		is := is.New(t)
-		is.Equal("strings", maybeFile("strings"))
+		bts, err := maybeFile("strings")
+		is.NoErr(err)
+		is.Equal("strings", string(bts))
 	})
 
 	t.Run("stdin", func(t *testing.T) {
 		is := is.New(t)
-		is.Equal("", maybeFile("-"))
+		bts, err := maybeFile("-")
+		is.NoErr(err)
+		is.Equal(0, len(bts))
 	})
 }
 

--- a/cmd/melt/main_test.go
+++ b/cmd/melt/main_test.go
@@ -181,24 +181,17 @@ func TestMaybeFile(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "f")
 		content := "test content"
 		is.NoErr(os.WriteFile(path, []byte(content), 0o644)) // nolint: gomnd
-
-		bts, err := maybeFile(path)
-		is.NoErr(err)
-		is.Equal(content, string(bts))
+		is.Equal(content, maybeFile(path))
 	})
 
 	t.Run("not a file", func(t *testing.T) {
 		is := is.New(t)
-		bts, err := maybeFile("strings")
-		is.NoErr(err)
-		is.Equal("strings", string(bts))
+		is.Equal("strings", maybeFile("strings"))
 	})
 
 	t.Run("stdin", func(t *testing.T) {
 		is := is.New(t)
-		bts, err := maybeFile("-")
-		is.NoErr(err)
-		is.Equal(0, len(bts))
+		is.Equal("", maybeFile("-"))
 	})
 }
 


### PR DESCRIPTION
allows to backup from a pipe, e.g.:

```sh
cat mykey | melt
```

It'll also allow to restore to STDOUT:

```sh
melt restore --seed "seed words" -
cat seed | melt restore -
```

So you can now do things like:

```sh
cat ~/.ssh/id_ed25519 | melt | melt restore -
```

which is not useful at all, but you could pipe it to/from `charm` once https://github.com/charmbracelet/charm/pull/139 is done