### PR TITLE
fix: add melt binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 completions/
 manpages/
+melt


### PR DESCRIPTION
The default build instructions will produce a melt binary in the root.